### PR TITLE
Ignoring files autogenerated by Visual Studio

### DIFF
--- a/VisualStudio.gitignore
+++ b/VisualStudio.gitignore
@@ -21,6 +21,8 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+*.vshost.exe.manifest
+*.vshost.exe.config
 
 # Visual Studio 2015 cache/options directory
 .vs/


### PR DESCRIPTION
These files should not be tracked by any repository as VS will generate them in situ. [Here](http://stackoverflow.com/questions/2736310/do-i-need-the-bin-debug-appname-vshost-exe-and-appname-vshost-manifest-in-my-svn) is a SO question about this. 
